### PR TITLE
BUGFix unable to initialize if first attempt fail

### DIFF
--- a/src/diskio.c
+++ b/src/diskio.c
@@ -56,8 +56,9 @@ DSTATUS disk_initialize (
 
   if(disk.is_initialized[pdrv] == 0)
   {
-    disk.is_initialized[pdrv] = 1;
     stat = disk.drv[pdrv]->disk_initialize(disk.lun[pdrv]);
+    if(! (stat & STA_NOINIT))
+	  disk.is_initialized[pdrv] = 1;
   }
   return stat;
 }


### PR DESCRIPTION
disk_initialize() mark disk as initialized even in case of failed drv->disk_initialize call. This make impossible to initialize disk after failed attempt and make it unavailable

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32_mw_fatfs/blob/master/CONTRIBUTING.md) file.
