### PR TITLE
fix: replacing NULL by 0 in osMessageQueuePut call

### DIFF
--- a/src/drivers/sd_diskio_dma_rtos_template_bspv1.c
+++ b/src/drivers/sd_diskio_dma_rtos_template_bspv1.c
@@ -615,7 +615,7 @@ void BSP_SD_WriteCpltCallback(void)
   osMessagePut(SDQueueID, WRITE_CPLT_MSG, 0);
 #else
   const uint16_t msg = WRITE_CPLT_MSG;
-  osMessageQueuePut(SDQueueID, (const void *)&msg, NULL, 0);
+  osMessageQueuePut(SDQueueID, (const void *)&msg, 0, 0);
 #endif
 }
 
@@ -635,7 +635,7 @@ void BSP_SD_ReadCpltCallback(void)
   osMessagePut(SDQueueID, READ_CPLT_MSG, 0);
 #else
   const uint16_t msg = READ_CPLT_MSG;
-  osMessageQueuePut(SDQueueID, (const void *)&msg, NULL, 0);
+  osMessageQueuePut(SDQueueID, (const void *)&msg, 0, 0);
 #endif
 }
 
@@ -648,7 +648,7 @@ void BSP_SD_AbortCallback(void)
 osMessagePut(SDQueueID, RW_ABORT_MSG, 0);
 #else
 const uint16_t msg = RW_ABORT_MSG;
-osMessageQueuePut(SDQueueID, (const void *)&msg, NULL, 0);
+osMessageQueuePut(SDQueueID, (const void *)&msg, 0, 0);
 #endif
 }
 */

--- a/src/drivers/sd_diskio_dma_rtos_template_bspv2.c
+++ b/src/drivers/sd_diskio_dma_rtos_template_bspv2.c
@@ -612,7 +612,7 @@ void BSP_SD_WriteCpltCallback(uint32_t Instance)
    osMessagePut(SDQueueID, WRITE_CPLT_MSG, 0);
 #else
    const uint16_t msg = WRITE_CPLT_MSG;
-   osMessageQueuePut(SDQueueID, (const void *)&msg, NULL, 0);
+   osMessageQueuePut(SDQueueID, (const void *)&msg, 0, 0);
 #endif
   }
 }
@@ -634,7 +634,7 @@ void BSP_SD_ReadCpltCallback(uint32_t Instance)
     osMessagePut(SDQueueID, READ_CPLT_MSG, 0);
 #else
     const uint16_t msg = READ_CPLT_MSG;
-    osMessageQueuePut(SDQueueID, (const void *)&msg, NULL, 0);
+    osMessageQueuePut(SDQueueID, (const void *)&msg, 0, 0);
 #endif
   }
 }
@@ -647,7 +647,7 @@ void BSP_SD_AbortCallback(uint32_t Instance)
     osMessagePut(SDQueueID, RW_ABORT_MSG, 0);
 #else
     const uint16_t msg = RW_ABORT_MSG;
-    osMessageQueuePut(SDQueueID, (const void *)&msg, NULL, 0);
+    osMessageQueuePut(SDQueueID, (const void *)&msg, 0, 0);
 #endif
   }
 }


### PR DESCRIPTION
Hi,

[As staten in the CMSIS-RTOS V2 docs](https://www.keil.com/pack/doc/CMSIS/RTOS2/html/group__CMSIS__RTOS__Message.html#gaa515fc8b956f721a8f72b2c505813bfc), `osMessageQueuePut()` takes an `uint8_t` for its `msg_prio` argument. The code supplied a `NULL` pointer instead of `0`, which triggers the following warning when compiling with STM32CubeIDE: 

**warning: passing argument 3 of 'osMessageQueuePut' makes integer from pointer without a cast [-Wint-conversion]**


I don't know if this change will apply automatically on the code generated by STM32CubeMX when FreeRTOS is enabled. Could you make sure it does?

Fixes #4 